### PR TITLE
DLS-12055 | Rate limit all users based on IP

### DIFF
--- a/app/uk/gov/hmrc/vatregisteredcompaniesfrontend/controllers/VatRegCoLookupController.scala
+++ b/app/uk/gov/hmrc/vatregisteredcompaniesfrontend/controllers/VatRegCoLookupController.scala
@@ -109,15 +109,15 @@ class VatRegCoLookupController @Inject()(
     unknown
   }
 
-  def knownWithValidConsultationNumber: Action[AnyContent] = Action.async { implicit request =>
+  def knownWithValidConsultationNumber: Action[AnyContent] = (Action andThen ipRateLimitFilter).async { implicit request =>
     known
   }
 
-  def knownWithInvalidConsultationNumber: Action[AnyContent] = Action.async { implicit request =>
+  def knownWithInvalidConsultationNumber: Action[AnyContent] = (Action andThen ipRateLimitFilter).async { implicit request =>
     known
   }
 
-  def knownWithoutConsultationNumber: Action[AnyContent] = Action.async { implicit request =>
+  def knownWithoutConsultationNumber: Action[AnyContent] = (Action andThen ipRateLimitFilter).async { implicit request =>
     known
   }
 

--- a/test/uk/gov/hmrc/vatregisteredcompaniesfrontend/controllers/VatRegCoLookupControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatregisteredcompaniesfrontend/controllers/VatRegCoLookupControllerSpec.scala
@@ -76,6 +76,9 @@ class VatRegCoLookupControllerSpec extends BaseSpec with BaseOneAppPerSuite {
     when(mockVatRegCoService.getLookupFromCache(any(), any())).thenReturn(OptionT.none[Future, Lookup])
 
     val actions: Seq[Action[AnyContent]] = Seq(
+      controller.knownWithoutConsultationNumber,
+      controller.knownWithInvalidConsultationNumber,
+      controller.knownWithValidConsultationNumber,
       controller.unknownWithoutConsultationNumber,
       controller.unknownWithValidConsultationNumber,
       controller.unknownWithInvalidConsultationNumber
@@ -222,7 +225,7 @@ class VatRegCoLookupControllerSpec extends BaseSpec with BaseOneAppPerSuite {
         OptionT.some[Future](LookupResponse(Some(vatRegCompany), requesterVatNo, Some(new ConsultationNumber("Valid")), ZonedDateTime.now()))
       )
 
-      val result = controller.knownWithValidConsultationNumber()(fakeRequest)
+      val result = controller.knownWithValidConsultationNumber()(fakeRequestWithIp)
 
       status(result) shouldBe OK
       contentType(result) shouldBe Some("text/html")
@@ -235,7 +238,7 @@ class VatRegCoLookupControllerSpec extends BaseSpec with BaseOneAppPerSuite {
         OptionT.some[Future](LookupResponse(Some(vatRegCompany), requesterVatNo, Some(new ConsultationNumber("Invalid")), ZonedDateTime.now()))
       )
 
-      val result = controller.knownWithInvalidConsultationNumber()(fakeRequest)
+      val result = controller.knownWithInvalidConsultationNumber()(fakeRequestWithIp)
 
       status(result) shouldBe OK
       contentType(result) shouldBe Some("text/html")
@@ -248,7 +251,7 @@ class VatRegCoLookupControllerSpec extends BaseSpec with BaseOneAppPerSuite {
         OptionT.some[Future](LookupResponse(Some(vatRegCompany), requesterVatNo, None, ZonedDateTime.now()))
       )
 
-      val result = controller.knownWithoutConsultationNumber()(fakeRequest)
+      val result = controller.knownWithoutConsultationNumber()(fakeRequestWithIp)
 
       status(result) shouldBe OK
       contentType(result) shouldBe Some("text/html")

--- a/test/uk/gov/hmrc/vatregisteredcompaniesfrontend/utils/BaseSpec.scala
+++ b/test/uk/gov/hmrc/vatregisteredcompaniesfrontend/utils/BaseSpec.scala
@@ -38,6 +38,7 @@ trait BaseSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with T
   val env: Environment = Environment.simple()
   val configuration: Configuration = Configuration.load(env)
   val fakeRequest = FakeRequest("GET", "/")
+  val fakeRequestWithIp = FakeRequest().withHeaders("True-Client-IP" -> "10.0.0.1")
   implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
   val cc: ControllerComponents = play.api.test.Helpers.stubControllerComponents()
   val mcc: MessagesControllerComponents = uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents()


### PR DESCRIPTION
- Restrict all users, even known lookups.
- For valid test cases, use another fake request that doesn't use loop back address